### PR TITLE
Add NCAR module_neural_net and pytorch-fortran

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Follow [contriburing instructions](https://github.com/TRACCS-COMPACT/hybrid_phys
 - [inference-engine](https://github.com/BerkeleyLab/fiats) : or ```Fiats```, as neural-fortran but leverage advanced Fortran 2023 features.
 - [Fortran-Keras-Bridge](https://github.com/scientific-computing/FKB) : convert models built and trained in Keras (TensorFlow) to one usables in Fortran, also provide Fortran module to load and use converted models.
 - [FNN](https://github.com/cerea-daml/fnn) : a Fortran module to implement simple, sequential neural network. Can also convert Keras model to FNN-useable model.
-
+- [module_neural_net](https://github.com/ESCOMP/PUMAS) : Single Fortran module for fully connected neural network inference with input/output scaling and optimized matrix multiplications and activations. Depends on BLAS/MKL and NetCDF. Part of NCAR PUMAS (used in CAM).
 
 ## 2. Python scripts from Fortran using Python bindings
 
@@ -24,6 +24,7 @@ Follow [contriburing instructions](https://github.com/TRACCS-COMPACT/hybrid_phys
 
 - [infero](https://github.com/ecmwf/infero) : Machine learning support library that runs pre-trained machine learning model for inference. Provides a common interface to multiple inference engines (TensorFlow LITE, TensorFlow C-API, ONNX-Runtime, TensorRT) and can be called from C/C++, Fortran or Python.
 - [FTorch](https://github.com/Cambridge-ICCS/FTorch) : Fortran wrapper to directly call PyTorch models for inference.
+- [pytorch-fortran](https://github.com/alexeedm/pytorch-fortran) : Fortran bindings to PyTorch for inference and training via TorchScript; pass Fortran arrays/tensors, run on CPU or GPU.
 - [Fortran-TF-lib](https://github.com/Cambridge-ICCS/fortran-tf-lib) : Fortran wrapper to directly call TensorFlow / Keras models for inference.
 - [TorchClim](https://zenodo.org/records/8390519) : Fortran wrapper to call PyTorch models. Also provide an additional layer to ease wrapping in the Community Earth System Model (CESM) framework.
 - [TorchFort](https://github.com/NVIDIA/TorchFort) : Fortran/C/C++ wrapper to call PyTorch model for training and inference. Also wrapp use of NVIDIA GPUs.

--- a/bibtex.bib
+++ b/bibtex.bib
@@ -173,3 +173,46 @@
       URL = {https://gmd.copernicus.org/articles/14/4401/2021/},
       DOI = {10.5194/gmd-14-4401-2021}
 }
+
+@software{module_neural_net,
+  title  = {module\_neural\_net (PUMAS Fortran neural network module)},
+  author = {ESCOMP},
+  year   = {2025},
+  url    = {https://github.com/ESCOMP/PUMAS}
+}
+
+@article{Sun2023,
+  author  = {Sun, Jian and Dennis, John M. and Mickelson, Sheri A. and Vanderwende, Brian and Gettelman, Andrew and Thayer-Calder, Katherine},
+  title   = {Acceleration of the Parameterization of Unified Microphysics Across Scales (PUMAS) on the Graphics Processing Unit (GPU) With Directive-Based Methods},
+  journal = {Journal of Advances in Modeling Earth Systems},
+  volume  = {15},
+  number  = {5},
+  pages   = {e2022MS003515},
+  keywords= {GPU, OpenACC, OpenMP target offload, PUMAS, CAM},
+  doi     = {https://doi.org/10.1029/2022MS003515},
+  url     = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2022MS003515},
+  eprint  = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2022MS003515},
+  note    = {e2022MS003515 2022MS003515},
+  year    = {2023}
+}
+
+@Article{Gettelman2023,
+  AUTHOR  = {Gettelman, A. and Morrison, H. and Eidhammer, T. and Thayer-Calder, K. and Sun, J. and Forbes, R. and McGraw, Z. and Zhu, J. and Storelvmo, T. and Dennis, J.},
+  TITLE   = {Importance of ice nucleation and precipitation on climate with the Parameterization of Unified Microphysics Across Scales version 1 (PUMASv1)},
+  JOURNAL = {Geoscientific Model Development},
+  VOLUME  = {16},
+  YEAR    = {2023},
+  NUMBER  = {6},
+  PAGES   = {1735--1754},
+  URL     = {https://gmd.copernicus.org/articles/16/1735/2023/},
+  DOI     = {10.5194/gmd-16-1735-2023}
+
+  @software{pytorch-fortran,
+  author  = {alexeedm},
+  title   = {pytorch-fortran: PyTorch bindings for Fortran},
+  year    = {2023},
+  url     = {https://github.com/alexeedm/pytorch-fortran},
+  version = {v0.4},
+  license = {MIT}
+}
+


### PR DESCRIPTION
- README: add module_neural_net under “1. Neural Networks in Fortran”
- README: add pytorch-fortran under “3. Leverage C/C++ bindings of ML libraries”
- bibtex: add @software{module_neural_net}, @article{Sun2023}, @Article{Gettelman2023}, @software{pytorch-fortran}

Also emailed you about pybind11, CFFI, and Triton Inference Server. 